### PR TITLE
Change spelling of Archiv to Archive

### DIFF
--- a/src/borg_backup_gui.cpp
+++ b/src/borg_backup_gui.cpp
@@ -163,20 +163,20 @@ static QString SH      = "sh",       // "/usr/bin/sh",
 // Status control of program queries and their values.
 static QString Borg_Info_OK,
                Borg_List_OK,
-              new_Archiv_OK,
+              new_Archive_OK,
                    Mount_OK,
                  Crontab_OK,
             save_Crontab_OK,
-            check_Archiv_OK,
+            check_Archive_OK,
         Borg_Detail_Info_OK,
          export_Profiles_OK,
                Borg_Info_ERROR,
                Borg_List_ERROR,
-              new_Archiv_ERROR,
+              new_Archive_ERROR,
                    Mount_ERROR,
                  Crontab_ERROR,
             save_Crontab_ERROR,
-            check_Archiv_ERROR,
+            check_Archive_ERROR,
         Borg_Detail_Info_ERROR,
          export_Profiles_ERROR,
                      ask_a,
@@ -269,29 +269,29 @@ void BORG_BackUP_GUI::run_Detail_JSON_Info(QString a){
 }
 
 // BORG: check whether an archive is available.
-void BORG_BackUP_GUI::Check_Borg_Archiv(QString a){
+void BORG_BackUP_GUI::Check_Borg_Archive(QString a){
     QProcess             process;
                          process.start(BORG + " info " + a);
                          process.waitForFinished(-1);
     QString     stdout = process.readAllStandardOutput(),
                 stderr = process.readAllStandardError();
-    check_Archiv_OK    = stdout;
-    check_Archiv_ERROR = stderr;
+    check_Archive_OK    = stdout;
+    check_Archive_ERROR = stderr;
 }
 
 // BORG: create a new Borg BackUP.
-void BORG_BackUP_GUI::new_Borg_Archiv(QString a){
+void BORG_BackUP_GUI::new_Borg_Archive(QString a){
     static QString START_BORG_PASSPHRASE = qgetenv("BORG_PASSPHRASE");
 
-    qputenv("BORG_PASSPHRASE", qPrintable(ui->Archiv_Key->text()));
+    qputenv("BORG_PASSPHRASE", qPrintable(ui->Archive_Key->text()));
 
     QProcess           process;
                        process.start(a);
                        process.waitForFinished(-1);
     QString   stdout = process.readAllStandardOutput(),
               stderr = process.readAllStandardError();
-    new_Archiv_OK    = stdout;
-    new_Archiv_ERROR = stderr;
+    new_Archive_OK    = stdout;
+    new_Archive_ERROR = stderr;
 
     qputenv("BORG_PASSPHRASE", qPrintable(START_BORG_PASSPHRASE));
 }
@@ -329,7 +329,7 @@ void BORG_BackUP_GUI::save_Crontab(){
     save_Crontab_ERROR = stderr;
 }
 
-// Export all profiles to the export folder run_export_Profiles("-zcvf", "Archiv_Name.tar.gz", "Path_to_Folder");
+// Export all profiles to the export folder run_export_Profiles("-zcvf", "Archive_Name.tar.gz", "Path_to_Folder");
 void BORG_BackUP_GUI::run_export_Profiles(QString x, QString y, QString z){
     QProcess                process;
                             process.start(TAR + " " + x + " " + y + " " + z);
@@ -876,11 +876,11 @@ void BORG_BackUP_GUI::Main_Window(){
           ui->Unlocked_Selecton->setIconSize(QSize(64, 64));
           ui->Unlocked_Selecton->setStyleSheet("padding: 2 0 0 0;");
           ui->Unlocked_Selecton->setStyleSheet("background:#999999;");
-                 ui->New_Archiv->setIcon(Icon_Lck1);
-                 ui->New_Archiv->setIconSize(Lck1_Icon.rect().size());
-                 ui->New_Archiv->setIconSize(QSize(32, 32));
-                 ui->New_Archiv->setStyleSheet("padding: 2 0 0 0;");
-                 ui->New_Archiv->setStyleSheet("background:#770000; color:#FFFFFF;");
+                 ui->New_Archive->setIcon(Icon_Lck1);
+                 ui->New_Archive->setIconSize(Lck1_Icon.rect().size());
+                 ui->New_Archive->setIconSize(QSize(32, 32));
+                 ui->New_Archive->setStyleSheet("padding: 2 0 0 0;");
+                 ui->New_Archive->setStyleSheet("background:#770000; color:#FFFFFF;");
                   ui->Remove_IN->setIcon(Icon_Trash);
                   ui->Remove_IN->setIconSize(Trash_Icon.rect().size());
                   ui->Remove_IN->setIconSize(QSize(32, 32));
@@ -1922,7 +1922,7 @@ void BORG_BackUP_GUI::on_AddChange_clicked(){
 }
 
 // --- BEG --- Integration of a new or existing archive.
-void BORG_BackUP_GUI::set_Archiv(){
+void BORG_BackUP_GUI::set_Archive(){
     QString a = ui->pathInfo_2->text(),
             b = QFileDialog::getExistingDirectory(this, tr("Select the BackUP directory"),Home_Path,
         QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks);
@@ -1936,8 +1936,8 @@ void BORG_BackUP_GUI::set_Archiv(){
         QFile   exists_BackUP_File(exists_BackUP),
                 exists_BackUP_File_removed(exists_BackUP_removed);
         if(exists_BackUP_File.exists() || exists_BackUP_File_removed.exists()){
-                 ui->Archiv_Key->setDisabled(true);
-            ui->Archiv_Key_File->setDisabled(true);
+                 ui->Archive_Key->setDisabled(true);
+            ui->Archive_Key_File->setDisabled(true);
             if(exists_BackUP_File.exists()){
                 ERROR("This BackUP is already in the BORG BackUP GUI maintenance!");
             }
@@ -1972,8 +1972,8 @@ void BORG_BackUP_GUI::set_Archiv(){
                          ui->pathInfo_3->setText(g);
                     QString h = e.replace(g,"");
                          ui->pathInfo_2->setText(h);
-                         ui->Archiv_Key->setEnabled(true);
-                    ui->Archiv_Key_File->setEnabled(true);
+                         ui->Archive_Key->setEnabled(true);
+                    ui->Archive_Key_File->setEnabled(true);
                     BackUP_Name = g;
                     QFile::rename(PATH+"/profiles/"+BackUP_Name+".removed", PATH+"/profiles/"+BackUP_Name+".PASSPHRASE");
                     read_all_Profiles();
@@ -1989,8 +1989,8 @@ void BORG_BackUP_GUI::set_Archiv(){
                          ui->pathInfo_3->setText(g);
                     QString h = e.replace(g,"");
                          ui->pathInfo_2->setText(h);
-                         ui->Archiv_Key->setEnabled(true);
-                    ui->Archiv_Key_File->setEnabled(true);
+                         ui->Archive_Key->setEnabled(true);
+                    ui->Archive_Key_File->setEnabled(true);
                     BackUP_Name = g;
                     QFile().remove(qPrintable(PATH+"/profiles/"+g+".removed"));
                        ui->frame_login->setGeometry(QRect(230, 110, 540, 80));
@@ -2017,9 +2017,9 @@ void BORG_BackUP_GUI::set_Archiv(){
             }
         }
         else if (!d.exists()){
-                ERROR("Not a Borg Archiv!");
-                     ui->Archiv_Key->setDisabled(true);
-                ui->Archiv_Key_File->setDisabled(true);
+                ERROR("Not a Borg Archive!");
+                     ui->Archive_Key->setDisabled(true);
+                ui->Archive_Key_File->setDisabled(true);
         }
         else{
             QString e = b;
@@ -2028,8 +2028,8 @@ void BORG_BackUP_GUI::set_Archiv(){
                  ui->pathInfo_3->setText(g);
             QString h = e.replace(g,"");
                  ui->pathInfo_2->setText(h);
-                 ui->Archiv_Key->setEnabled(true);
-            ui->Archiv_Key_File->setEnabled(true);
+                 ui->Archive_Key->setEnabled(true);
+            ui->Archive_Key_File->setEnabled(true);
             BackUP_Name = g;
                ui->frame_login->setGeometry(QRect(230, 110, 540, 80));
                  ui->tabWidget->setEnabled(false);
@@ -2295,12 +2295,12 @@ void BORG_BackUP_GUI::Random_Key_Base64(int x, int y){
     ui->progressBar_4->setValue(100);
 }
 
-// Archiv Key: create a key with selected excess length!
-void BORG_BackUP_GUI::create_Archiv_Key_length(){
-    QString a =      ui->Archiv_Key->text(),
-            b = ui->Archiv_Key_File->currentText(),
+// Archive Key: create a key with selected excess length!
+void BORG_BackUP_GUI::create_Archive_Key_length(){
+    QString a =      ui->Archive_Key->text(),
+            b = ui->Archive_Key_File->currentText(),
             c = "",
-         Name = ui->new_Archiv_Name->text();
+         Name = ui->new_Archive_Name->text();
     if(a=="" && b!="none"){
         if(b=="1024++"){
             Random_Key_Base64(33,33);
@@ -2340,26 +2340,26 @@ void BORG_BackUP_GUI::create_Archiv_Key_length(){
       ui->progressBar_4->setValue(0);
     QPixmap Lck1_Icon(PATH+"/images/locked.png");
     QIcon   Icon_Lck1(Lck1_Icon);
-         ui->Archiv_Key->setEnabled(false);
-    ui->Archiv_Key_File->setEnabled(false);
+         ui->Archive_Key->setEnabled(false);
+    ui->Archive_Key_File->setEnabled(false);
 }
 
 
-// Archiv Key: activate or deactivate activities of the different options when entering the password.
-void BORG_BackUP_GUI::Archiv_Key_Changed(){
-    QString a =      ui->Archiv_Key->text(),
-            b = ui->Archiv_Key_File->currentText();
+// Archive Key: activate or deactivate activities of the different options when entering the password.
+void BORG_BackUP_GUI::Archive_Key_Changed(){
+    QString a =      ui->Archive_Key->text(),
+            b = ui->Archive_Key_File->currentText();
     if(a!=""){
-        ui->Archiv_Key_File->setDisabled(true);
+        ui->Archive_Key_File->setDisabled(true);
     }
     else{
-         ui->Archiv_Key_File->setEnabled(true);
+         ui->Archive_Key_File->setEnabled(true);
     }
     if(b!="none"){
-        ui->Archiv_Key->setDisabled(true);
+        ui->Archive_Key->setDisabled(true);
     }
     else{
-         ui->Archiv_Key->setEnabled(true);
+         ui->Archive_Key->setEnabled(true);
     }
     if(a!="" || b!="none"){
         ui->Create->setEnabled(true);
@@ -2369,16 +2369,16 @@ void BORG_BackUP_GUI::Archiv_Key_Changed(){
     }
 }
 
-// Archiv Key: call Archive_Key_Changed() for changes in the text field. QString b = a currently unused!
-void BORG_BackUP_GUI::on_Archiv_Key_textChanged(const QString a){
+// Archive Key: call Archive_Key_Changed() for changes in the text field. QString b = a currently unused!
+void BORG_BackUP_GUI::on_Archive_Key_textChanged(const QString a){
     QString b = a;
-    Archiv_Key_Changed();
+    Archive_Key_Changed();
 }
 
-// Archiv Key: call Archive_Key_Changed() for changes in the key selection. QString b = a currently unused!
-void BORG_BackUP_GUI::on_Archiv_Key_File_currentTextChanged(const QString a){
+// Archive Key: call Archive_Key_Changed() for changes in the key selection. QString b = a currently unused!
+void BORG_BackUP_GUI::on_Archive_Key_File_currentTextChanged(const QString a){
     QString b = a;
-    Archiv_Key_Changed();
+    Archive_Key_Changed();
 }
 // END Build a Keyfile –––––––––––––––––––––––––––––––––––––––––––––––––––––––
 
@@ -2422,9 +2422,9 @@ void BORG_BackUP_GUI::on_pass_OK_clicked(){
     else{
         qputenv("BORG_PASSPHRASE", qPrintable(ui->pass->text()));
     }
-    Check_Borg_Archiv(BackUP_Path.replace("\"","")+BackUP_Name.replace("\"",""));
+    Check_Borg_Archive(BackUP_Path.replace("\"","")+BackUP_Name.replace("\"",""));
 // Is executed if the archive exists and no error (borg info call) is issued.
-    if (check_Archiv_OK.contains("Repository ID", Qt::CaseSensitive)){
+    if (check_Archive_OK.contains("Repository ID", Qt::CaseSensitive)){
           ui->add_NEW_BackUP->hide();
             ui->all_Profiles->setGeometry(QRect(-20, -940, 1040, 810));
         ui->frame_login_info->setGeometry(QRect(20, -100, 410, 60));
@@ -2438,7 +2438,7 @@ void BORG_BackUP_GUI::on_pass_OK_clicked(){
         Main_Window();
     }
 // If executed, there should be an error when executing "borg info" for the archive.
-    if (check_Archiv_ERROR.contains("incorrect", Qt::CaseSensitive) || check_Archiv_ERROR.contains("error", Qt::CaseSensitive)){
+    if (check_Archive_ERROR.contains("incorrect", Qt::CaseSensitive) || check_Archive_ERROR.contains("error", Qt::CaseSensitive)){
         ui->add_NEW_BackUP->show();
         ui->login_black_BG->setGeometry(QRect(-20, 0, 1040, 910));
           ui->all_Profiles->setGeometry(QRect(230, 180, 540, 260));
@@ -2840,8 +2840,8 @@ void BORG_BackUP_GUI::save_BackUP(QString mode){
     QString BackUP_A =      ui->pathInfo_3->text(),
             BackUP_B =      ui->pathInfo_2->text();
     if(mode=="new" || mode=="init"){
-            BackUP_A = ui->new_Archiv_Name->text();
-            BackUP_B = ui->new_Archiv_Path->text()+"/";
+            BackUP_A = ui->new_Archive_Name->text();
+            BackUP_B = ui->new_Archive_Path->text()+"/";
     }
     QString BackUP = "BackUP_Name=\"" + BackUP_A + "\"\nBackUP_Path=\"" + BackUP_B +"\"\n",
             Compression    = " " + ui->test_Pack->text(),
@@ -2959,9 +2959,9 @@ void BORG_BackUP_GUI::save_BackUP(QString mode){
     o.replace("''","").replace("//","/");
     QString INFO_SH_TEXT = "#!/bin/sh\n# BORG BackUP GUI\n# created by Marc-André Tragé\n# \n# This script was created automatically and should not be changed.\n# Direct changes in the script that are not made by Borg BackUP GUI\n# could lead to errors in the function as well as in BackUP!\n#\n# More information and help can be found here:\n# https://github.com/MTrage/Borg-BackUP-GUI\n\n",
             Script       = INFO_SH_TEXT + BackUP + BackUP_Parameters + Data_IN + Data_OUT + Mount_Path + File_Managers + "date=$(date +\"%Y.%m.%d-%H:%M:%S\")\n" + "borg create" + Compression + "--comment \"$BORG_Snapshot_Comment\" " + BackUP_B + BackUP_A + "::$date \\\n" + o;
-    QString new_Archiv_Name_TEXT = ui->new_Archiv_Name->text().replace("\"","");
+    QString new_Archive_Name_TEXT = ui->new_Archive_Name->text().replace("\"","");
     if(mode=="init"){
-       BackUP_Name = ui->new_Archiv_Name->text();
+       BackUP_Name = ui->new_Archive_Name->text();
     }
     QFile file(PATH + "/profiles/" + BackUP_Name + ".sh");
           file.open(QIODevice::WriteOnly | QIODevice::Text);
@@ -2971,9 +2971,9 @@ void BORG_BackUP_GUI::save_BackUP(QString mode){
     Changes_in_Areas = 0;
     QString PASS_KEY = "export BORG_PASSPHRASE='B O R G P A S S P H R A S E'\n\n";
     if(mode=="init"){
-       BackUP_Name = ui->new_Archiv_Name->text();
-       PASS_KEY = "export BORG_PASSCOMMAND=''\nexport BORG_PASSPHRASE='" + ui->Archiv_Key->text() + "'\n\n";
-       if(ui->Archiv_Key->text()==""){
+       BackUP_Name = ui->new_Archive_Name->text();
+       PASS_KEY = "export BORG_PASSCOMMAND=''\nexport BORG_PASSPHRASE='" + ui->Archive_Key->text() + "'\n\n";
+       if(ui->Archive_Key->text()==""){
            PASS_KEY = "export BORG_PASSPHRASE=''\nexport BORG_PASSCOMMAND='cat " + PATH + "/profiles/." + BackUP_Name +".key'\n\n";
        }
     }
@@ -2986,14 +2986,14 @@ void BORG_BackUP_GUI::save_BackUP(QString mode){
                                         "START_PATH=\"`dirname \\\"$0\\\"`\"\n"
                                         "sh $START_PATH/" + BackUP_Name.replace("\"","") + ".sh $1";
     if(mode=="new"){
-        QFile fileA(PATH + "/profiles/" + new_Archiv_Name_TEXT + ".PASSPHRASE");
+        QFile fileA(PATH + "/profiles/" + new_Archive_Name_TEXT + ".PASSPHRASE");
               fileA.open(QIODevice::WriteOnly | QIODevice::Text);
         QTextStream outA(&fileA);
         outA << PASSPHRASE;
         fileA.close();
     }
     if(mode=="init"){
-        QFile fileB(PATH + "/profiles/" + new_Archiv_Name_TEXT + ".PASSPHRASE");
+        QFile fileB(PATH + "/profiles/" + new_Archive_Name_TEXT + ".PASSPHRASE");
               fileB.open(QIODevice::WriteOnly | QIODevice::Text);
         QTextStream outB(&fileB);
         outB << PASSPHRASE;
@@ -3079,7 +3079,7 @@ void BORG_BackUP_GUI::on_all_Profiles_currentRowChanged(int currentRow){
 void BORG_BackUP_GUI::on_add_NEW_BackUP_clicked(){
     ui->all_Profiles->setEnabled(false);
     qApp->processEvents();
-    set_Archiv();
+    set_Archive();
     ui->all_Profiles->setEnabled(true);
 }
 
@@ -3152,69 +3152,69 @@ void BORG_BackUP_GUI::on_remove_BackUP_clicked(){
     }
 }
 
-// New Archiv Area: Activates the GUI for a new BackUP.
-void BORG_BackUP_GUI::on_New_Archiv_clicked(){
+// New Archive Area: Activates the GUI for a new BackUP.
+void BORG_BackUP_GUI::on_New_Archive_clicked(){
     QPixmap Lck2_Icon(PATH+"/images/unlocked.png");
     QIcon   Icon_Lck2(Lck2_Icon);
     ui->BackUP_Path->setEnabled(true);
-     ui->New_Archiv->setEnabled(false);
-     ui->New_Archiv->setIcon(Icon_Lck2);
-     ui->New_Archiv->setIconSize(Lck2_Icon.rect().size());
-     ui->New_Archiv->setIconSize(QSize(32, 32));
-     ui->New_Archiv->setStyleSheet("padding: 2 0 0 0;");
-     ui->New_Archiv->setStyleSheet("background:#000077; color:#FFFFFF;");
+     ui->New_Archive->setEnabled(false);
+     ui->New_Archive->setIcon(Icon_Lck2);
+     ui->New_Archive->setIconSize(Lck2_Icon.rect().size());
+     ui->New_Archive->setIconSize(QSize(32, 32));
+     ui->New_Archive->setStyleSheet("padding: 2 0 0 0;");
+     ui->New_Archive->setStyleSheet("background:#000077; color:#FFFFFF;");
 }
 
-// New Archiv Area: If the path was specified, the name entry is enabled in the GUI.
-void BORG_BackUP_GUI::on_new_Archiv_Path_textChanged(const QString &arg1){
+// New Archive Area: If the path was specified, the name entry is enabled in the GUI.
+void BORG_BackUP_GUI::on_new_Archive_Path_textChanged(const QString &arg1){
     if(arg1!=""){
-        ui->new_Archiv_Name->setEnabled(true);
+        ui->new_Archive_Name->setEnabled(true);
     }
     else{
-        ui->new_Archiv_Name->setEnabled(false);
+        ui->new_Archive_Name->setEnabled(false);
     }
 }
 
-// New Archiv Area: Allows the user to specify the BackUP path.
+// New Archive Area: Allows the user to specify the BackUP path.
 void BORG_BackUP_GUI::on_BackUP_Path_clicked(){
-    QString a = ui->new_Archiv_Path->text(),
+    QString a = ui->new_Archive_Path->text(),
             b = QFileDialog::getExistingDirectory(this, tr("Select a BackUP directory"),
         Home_Path,
         QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks);
     int c = b.length();
     if(c!=0){
-        ui->new_Archiv_Path->setText(b);
+        ui->new_Archive_Path->setText(b);
     }
 }
 
-// New Archiv Area: If the BackUP name was specified, the KEY functions are released in the GUI.
-void BORG_BackUP_GUI::on_new_Archiv_Name_textChanged(const QString &arg1){
+// New Archive Area: If the BackUP name was specified, the KEY functions are released in the GUI.
+void BORG_BackUP_GUI::on_new_Archive_Name_textChanged(const QString &arg1){
     if(arg1!=""){
-        QString a = ui->new_Archiv_Name->text();
+        QString a = ui->new_Archive_Name->text();
         a.replace("\"","-").replace("\\","-").replace(" ","-").replace(",","-").replace(";","-").replace("/","-");
-        ui->new_Archiv_Name->setText(a);
-             ui->Archiv_Key->setEnabled(true);
-        ui->Archiv_Key_File->setEnabled(true);
+        ui->new_Archive_Name->setText(a);
+             ui->Archive_Key->setEnabled(true);
+        ui->Archive_Key_File->setEnabled(true);
     }
     else{
-             ui->Archiv_Key->setEnabled(false);
-        ui->Archiv_Key_File->setEnabled(false);
+             ui->Archive_Key->setEnabled(false);
+        ui->Archive_Key_File->setEnabled(false);
                  ui->Create->setEnabled(false);
     }
 }
 
-// New Archiv Area: Reads all entered data for a new BackUP and creates a new BackUP.
+// New Archive Area: Reads all entered data for a new BackUP and creates a new BackUP.
 void BORG_BackUP_GUI::on_Create_clicked(){
     QPixmap Lck1_Icon(PATH+"/images/locked.png");
     QIcon   Icon_Lck1(Lck1_Icon);
-    ui->New_Archiv->setIcon(Icon_Lck1);
-    ui->New_Archiv->setIconSize(Lck1_Icon.rect().size());
-    ui->New_Archiv->setIconSize(QSize(32, 32));
-    ui->New_Archiv->setStyleSheet("padding: 2 0 0 0;");
-    ui->New_Archiv->setStyleSheet("background:#770000; color:#FFFFFF;");
-    QString a = ui->new_Archiv_Path->text(),
-            b = ui->new_Archiv_Name->text(),
-            c =      ui->Archiv_Key->text();
+    ui->New_Archive->setIcon(Icon_Lck1);
+    ui->New_Archive->setIconSize(Lck1_Icon.rect().size());
+    ui->New_Archive->setIconSize(QSize(32, 32));
+    ui->New_Archive->setStyleSheet("padding: 2 0 0 0;");
+    ui->New_Archive->setStyleSheet("background:#770000; color:#FFFFFF;");
+    QString a = ui->new_Archive_Path->text(),
+            b = ui->new_Archive_Name->text(),
+            c =      ui->Archive_Key->text();
     setDisabled(true);
     QFile d(PATH + "/profiles/." + b + ".key");
     if(d.exists()){
@@ -3227,20 +3227,20 @@ void BORG_BackUP_GUI::on_Create_clicked(){
              "<b>The path to the key is:</b><BR>"+ PATH + "/profiles/." + b + ".key");
     }
     else{
-        if(ui->Archiv_Key->text()==""){
-            create_Archiv_Key_length();
+        if(ui->Archive_Key->text()==""){
+            create_Archive_Key_length();
         }
     }
-    QString e = ui->new_Archiv_Path->text() + "/" + ui->new_Archiv_Name->text(),
+    QString e = ui->new_Archive_Path->text() + "/" + ui->new_Archive_Name->text(),
             f = " --encryption=repokey";
-    if(ui->Archiv_Key->text()==""){
+    if(ui->Archive_Key->text()==""){
         f = " --encryption=keyfile";
     }
     QString g = BORG + " init " + e + f ;
     save_BackUP("init");
-    new_Borg_Archiv(g);
+    new_Borg_Archive(g);
     ui->progressBar_4->setEnabled(true);
-    if(ui->Archiv_Key->text()==""){
+    if(ui->Archive_Key->text()==""){
         QPixmap ci(PATH+"/images/logo.svg");
         QMessageBox sa;
                     sa.setWindowTitle("Watch your step...");
@@ -3277,14 +3277,14 @@ void BORG_BackUP_GUI::on_Create_clicked(){
             break;
         }
     }
-    ui->new_Archiv_Path->setText("");
-    ui->new_Archiv_Name->setText("");
-        ui->BackUP_Path->setEnabled(false);
-         ui->New_Archiv->setEnabled(true);
-         ui->Archiv_Key->setText("");
-    ui->Archiv_Key_File->setCurrentIndex(0);
-         ui->Archiv_Key->setDisabled(true);
-    ui->Archiv_Key_File->setDisabled(true);
+    ui->new_Archive_Path->setText("");
+    ui->new_Archive_Name->setText("");
+    ui->BackUP_Path->setEnabled(false);
+        ui->New_Archive->setEnabled(true);
+        ui->Archive_Key->setText("");
+         ui->Archive_Key_File->setCurrentIndex(0);
+         ui->Archive_Key->setDisabled(true);
+    ui->Archive_Key_File->setDisabled(true);
 }
 
 // Unlocking the Comment Manager

--- a/src/borg_backup_gui.h
+++ b/src/borg_backup_gui.h
@@ -63,8 +63,8 @@ private slots:
     void INFO(QString c);
     void Show_Hide();
 
-    void Check_Borg_Archiv(QString a);
-    void new_Borg_Archiv(QString a);
+    void Check_Borg_Archive(QString a);
+    void new_Borg_Archive(QString a);
     void write_html_Page();
 
     void run_JSON_Info();
@@ -76,7 +76,7 @@ private slots:
 
     void save_Crontab();
     void check_File_Managers(QString a);
-    void Archiv_Key_Changed();
+    void Archive_Key_Changed();
     void Compression_Type_Value_remove_Items();
     void Weekday_Check();
     void Compression_Build_String();
@@ -85,8 +85,8 @@ private slots:
     void read_all_Profiles();
     void Build_Dir_File();
     void read_Dir_File(QString a, QString ai);
-    void create_Archiv_Key_length();
-    void set_Archiv();
+    void create_Archive_Key_length();
+    void set_Archive();
 
     void on_BackUP_NOW_clicked();
     void on_Mount_clicked();
@@ -113,8 +113,8 @@ private slots:
     void on_Compression_none_auto_currentIndexChanged(const QString a);
     void on_Compression_Type_Value_currentIndexChanged(QString a);
     void on_Status_currentIndexChanged(const QString a);
-    void on_Archiv_Key_textChanged(const QString a);
-    void on_Archiv_Key_File_currentTextChanged(const QString a);
+    void on_Archive_Key_textChanged(const QString a);
+    void on_Archive_Key_File_currentTextChanged(const QString a);
     void on_pass_OK_clicked();
     void on_pass_returnPressed();
     void on_pass_textChanged(const QString a);
@@ -139,11 +139,11 @@ private slots:
     void on_Save_Compression_Config_clicked();
     void on_Save_Mount_Config_clicked();
     void on_remove_BackUP_clicked();
-    void on_New_Archiv_clicked();
+    void on_New_Archive_clicked();
     void on_Create_clicked();
     void on_BackUP_Path_clicked();
-    void on_new_Archiv_Path_textChanged(const QString &arg1);
-    void on_new_Archiv_Name_textChanged(const QString &arg1);
+    void on_new_Archive_Path_textChanged(const QString &arg1);
+    void on_new_Archive_Name_textChanged(const QString &arg1);
 
     void on_Change_3_clicked();
 

--- a/src/borg_backup_gui.ui
+++ b/src/borg_backup_gui.ui
@@ -2960,7 +2960,7 @@ p, li { white-space: pre-wrap; }
     </widget>
     <widget class="QWidget" name="NewArchiv">
      <attribute name="title">
-      <string>&amp;New Archiv</string>
+      <string>&amp;New Archive</string>
      </attribute>
      <widget class="QLabel" name="label_18">
       <property name="geometry">
@@ -3034,7 +3034,7 @@ p, li { white-space: pre-wrap; }
        <string>BackUP Path</string>
       </property>
      </widget>
-     <widget class="QComboBox" name="Archiv_Key_File">
+     <widget class="QComboBox" name="Archive_Key_File">
       <property name="enabled">
        <bool>false</bool>
       </property>
@@ -3075,7 +3075,7 @@ p, li { white-space: pre-wrap; }
        </property>
       </item>
      </widget>
-     <widget class="QLineEdit" name="new_Archiv_Name">
+     <widget class="QLineEdit" name="new_Archive_Name">
       <property name="enabled">
        <bool>false</bool>
       </property>
@@ -3106,7 +3106,7 @@ background:#cccccc;</string>
        <bool>false</bool>
       </property>
      </widget>
-     <widget class="QLineEdit" name="Archiv_Key">
+     <widget class="QLineEdit" name="Archive_Key">
       <property name="enabled">
        <bool>false</bool>
       </property>
@@ -3241,7 +3241,7 @@ background:#cccccc;</string>
        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
       </property>
      </widget>
-     <widget class="QLineEdit" name="new_Archiv_Path">
+     <widget class="QLineEdit" name="new_Archive_Path">
       <property name="enabled">
        <bool>false</bool>
       </property>
@@ -3357,7 +3357,7 @@ border-radius: 3px;
        <string/>
       </property>
      </widget>
-     <widget class="QPushButton" name="New_Archiv">
+     <widget class="QPushButton" name="New_Archive">
       <property name="enabled">
        <bool>true</bool>
       </property>
@@ -3380,7 +3380,7 @@ border-radius: 3px;
        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select a folder.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
       </property>
       <property name="text">
-       <string>New Archiv</string>
+       <string>New Archive</string>
       </property>
      </widget>
      <widget class="QTextBrowser" name="textBrowser_7">
@@ -3479,19 +3479,19 @@ p, li { white-space: pre-wrap; }
      <zorder>label_18</zorder>
      <zorder>label_17</zorder>
      <zorder>BackUP_Path</zorder>
-     <zorder>Archiv_Key_File</zorder>
-     <zorder>new_Archiv_Name</zorder>
-     <zorder>Archiv_Key</zorder>
+     <zorder>Archive_Key_File</zorder>
+     <zorder>new_Archive_Name</zorder>
+     <zorder>Archive_Key</zorder>
      <zorder>label_19</zorder>
      <zorder>Create</zorder>
      <zorder>label_27</zorder>
      <zorder>label_20</zorder>
-     <zorder>new_Archiv_Path</zorder>
+     <zorder>new_Archive_Path</zorder>
      <zorder>textBrowser_6</zorder>
      <zorder>textBrowser_8</zorder>
      <zorder>line_8</zorder>
      <zorder>progressBar_4</zorder>
-     <zorder>New_Archiv</zorder>
+     <zorder>New_Archive</zorder>
     </widget>
     <widget class="QWidget" name="Help">
      <attribute name="title">
@@ -4430,12 +4430,12 @@ background: qlineargradient(x2:1, y1:1, x1:1, y1:1, stop: 0 rgba(120,200,255,255
     <string>&amp;Tutorial</string>
    </property>
   </action>
-  <action name="actionLoad_Archiv">
+  <action name="actionLoad_Archive">
    <property name="text">
-    <string>Load Archiv</string>
+    <string>Load Archive</string>
    </property>
   </action>
-  <action name="Set_Archiv">
+  <action name="Set_Archive">
    <property name="text">
     <string>&amp;Select a BackUP</string>
    </property>

--- a/src/ui_borg_backup_gui.h
+++ b/src/ui_borg_backup_gui.h
@@ -52,8 +52,8 @@ public:
     QAction *Configuration_Menu;
     QAction *Borg_Homepage_Menu;
     QAction *Tutorial_Menu;
-    QAction *actionLoad_Archiv;
-    QAction *Set_Archiv;
+    QAction *actionLoad_Archive;
+    QAction *Set_Archive;
     QAction *Open;
     QWidget *Main;
     QTabWidget *tabWidget;
@@ -169,17 +169,17 @@ public:
     QLabel *label_18;
     QLabel *label_17;
     QPushButton *BackUP_Path;
-    QComboBox *Archiv_Key_File;
-    QLineEdit *new_Archiv_Name;
-    QLineEdit *Archiv_Key;
+    QComboBox *Archive_Key_File;
+    QLineEdit *new_Archive_Name;
+    QLineEdit *Archive_Key;
     QLabel *label_19;
     QPushButton *Create;
     QLabel *label_27;
     QLabel *label_20;
-    QLineEdit *new_Archiv_Path;
+    QLineEdit *new_Archive_Path;
     QTextBrowser *textBrowser_6;
     QProgressBar *progressBar_4;
-    QPushButton *New_Archiv;
+    QPushButton *New_Archive;
     QTextBrowser *textBrowser_7;
     QTextBrowser *textBrowser_8;
     QFrame *line_8;
@@ -259,10 +259,10 @@ public:
         Borg_Homepage_Menu->setObjectName(QStringLiteral("Borg_Homepage_Menu"));
         Tutorial_Menu = new QAction(BORG_BackUP_GUI);
         Tutorial_Menu->setObjectName(QStringLiteral("Tutorial_Menu"));
-        actionLoad_Archiv = new QAction(BORG_BackUP_GUI);
-        actionLoad_Archiv->setObjectName(QStringLiteral("actionLoad_Archiv"));
-        Set_Archiv = new QAction(BORG_BackUP_GUI);
-        Set_Archiv->setObjectName(QStringLiteral("Set_Archiv"));
+        actionLoad_Archive = new QAction(BORG_BackUP_GUI);
+        actionLoad_Archive->setObjectName(QStringLiteral("actionLoad_Archive"));
+        Set_Archive = new QAction(BORG_BackUP_GUI);
+        Set_Archive->setObjectName(QStringLiteral("Set_Archive"));
         Open = new QAction(BORG_BackUP_GUI);
         Open->setObjectName(QStringLiteral("Open"));
         Main = new QWidget(BORG_BackUP_GUI);
@@ -1213,40 +1213,40 @@ public:
         BackUP_Path->setEnabled(false);
         BackUP_Path->setGeometry(QRect(10, 230, 220, 40));
         BackUP_Path->setFont(font1);
-        Archiv_Key_File = new QComboBox(NewArchiv);
-        Archiv_Key_File->addItem(QString());
-        Archiv_Key_File->addItem(QString());
-        Archiv_Key_File->addItem(QString());
-        Archiv_Key_File->addItem(QString());
-        Archiv_Key_File->addItem(QString());
-        Archiv_Key_File->setObjectName(QStringLiteral("Archiv_Key_File"));
-        Archiv_Key_File->setEnabled(false);
-        Archiv_Key_File->setGeometry(QRect(750, 410, 240, 40));
-        Archiv_Key_File->setStyleSheet(QStringLiteral(""));
-        new_Archiv_Name = new QLineEdit(NewArchiv);
-        new_Archiv_Name->setObjectName(QStringLiteral("new_Archiv_Name"));
-        new_Archiv_Name->setEnabled(false);
-        new_Archiv_Name->setGeometry(QRect(610, 230, 380, 40));
-        new_Archiv_Name->setFont(font4);
-        new_Archiv_Name->setStyleSheet(QLatin1String("border-radius: 4px;\n"
+        Archive_Key_File = new QComboBox(NewArchiv);
+        Archive_Key_File->addItem(QString());
+        Archive_Key_File->addItem(QString());
+        Archive_Key_File->addItem(QString());
+        Archive_Key_File->addItem(QString());
+        Archive_Key_File->addItem(QString());
+        Archive_Key_File->setObjectName(QStringLiteral("Archive_Key_File"));
+        Archive_Key_File->setEnabled(false);
+        Archive_Key_File->setGeometry(QRect(750, 410, 240, 40));
+        Archive_Key_File->setStyleSheet(QStringLiteral(""));
+        new_Archive_Name = new QLineEdit(NewArchiv);
+        new_Archive_Name->setObjectName(QStringLiteral("new_Archive_Name"));
+        new_Archive_Name->setEnabled(false);
+        new_Archive_Name->setGeometry(QRect(610, 230, 380, 40));
+        new_Archive_Name->setFont(font4);
+        new_Archive_Name->setStyleSheet(QLatin1String("border-radius: 4px;\n"
 "border-top: 2px solid #000000;\n"
 "border-left: 2px solid #000000;\n"
 "border-bottom: 2px solid #FFFFFF;\n"
 "border-right: 2px solid #FFFFFF;\n"
 "background:#cccccc;"));
-        new_Archiv_Name->setReadOnly(false);
-        Archiv_Key = new QLineEdit(NewArchiv);
-        Archiv_Key->setObjectName(QStringLiteral("Archiv_Key"));
-        Archiv_Key->setEnabled(false);
-        Archiv_Key->setGeometry(QRect(10, 410, 690, 40));
-        Archiv_Key->setFont(font4);
-        Archiv_Key->setStyleSheet(QLatin1String("border-radius: 4px;\n"
+        new_Archive_Name->setReadOnly(false);
+        Archive_Key = new QLineEdit(NewArchiv);
+        Archive_Key->setObjectName(QStringLiteral("Archive_Key"));
+        Archive_Key->setEnabled(false);
+        Archive_Key->setGeometry(QRect(10, 410, 690, 40));
+        Archive_Key->setFont(font4);
+        Archive_Key->setStyleSheet(QLatin1String("border-radius: 4px;\n"
 "border-top: 2px solid #000000;\n"
 "border-left: 2px solid #000000;\n"
 "border-bottom: 2px solid #FFFFFF;\n"
 "border-right: 2px solid #FFFFFF;\n"
 "background:#cccccc;"));
-        Archiv_Key->setReadOnly(false);
+        Archive_Key->setReadOnly(false);
         label_19 = new QLabel(NewArchiv);
         label_19->setObjectName(QStringLiteral("label_19"));
         label_19->setEnabled(true);
@@ -1270,18 +1270,18 @@ public:
         label_20->setGeometry(QRect(750, 380, 240, 30));
         label_20->setFont(font4);
         label_20->setAlignment(Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter);
-        new_Archiv_Path = new QLineEdit(NewArchiv);
-        new_Archiv_Path->setObjectName(QStringLiteral("new_Archiv_Path"));
-        new_Archiv_Path->setEnabled(false);
-        new_Archiv_Path->setGeometry(QRect(240, 230, 360, 40));
-        new_Archiv_Path->setFont(font4);
-        new_Archiv_Path->setStyleSheet(QLatin1String("color:#555555;\n"
+        new_Archive_Path = new QLineEdit(NewArchiv);
+        new_Archive_Path->setObjectName(QStringLiteral("new_Archive_Path"));
+        new_Archive_Path->setEnabled(false);
+        new_Archive_Path->setGeometry(QRect(240, 230, 360, 40));
+        new_Archive_Path->setFont(font4);
+        new_Archive_Path->setStyleSheet(QLatin1String("color:#555555;\n"
 "border-radius: 4px;\n"
 "border-width:2px;\n"
 "border-style:ridge;\n"
 "border-color:#888888;\n"
 "background:#cccccc;"));
-        new_Archiv_Path->setReadOnly(true);
+        new_Archive_Path->setReadOnly(true);
         textBrowser_6 = new QTextBrowser(NewArchiv);
         textBrowser_6->setObjectName(QStringLiteral("textBrowser_6"));
         textBrowser_6->setGeometry(QRect(0, 10, 970, 150));
@@ -1311,11 +1311,11 @@ public:
         progressBar_4->setValue(0);
         progressBar_4->setAlignment(Qt::AlignCenter);
         progressBar_4->setOrientation(Qt::Horizontal);
-        New_Archiv = new QPushButton(NewArchiv);
-        New_Archiv->setObjectName(QStringLiteral("New_Archiv"));
-        New_Archiv->setEnabled(true);
-        New_Archiv->setGeometry(QRect(10, 180, 220, 40));
-        New_Archiv->setFont(font4);
+        New_Archive = new QPushButton(NewArchiv);
+        New_Archive->setObjectName(QStringLiteral("New_Archive"));
+        New_Archive->setEnabled(true);
+        New_Archive->setGeometry(QRect(10, 180, 220, 40));
+        New_Archive->setFont(font4);
         textBrowser_7 = new QTextBrowser(NewArchiv);
         textBrowser_7->setObjectName(QStringLiteral("textBrowser_7"));
         textBrowser_7->setGeometry(QRect(0, 310, 970, 70));
@@ -1346,19 +1346,19 @@ public:
         label_18->raise();
         label_17->raise();
         BackUP_Path->raise();
-        Archiv_Key_File->raise();
-        new_Archiv_Name->raise();
-        Archiv_Key->raise();
+        Archive_Key_File->raise();
+        new_Archive_Name->raise();
+        Archive_Key->raise();
         label_19->raise();
         Create->raise();
         label_27->raise();
         label_20->raise();
-        new_Archiv_Path->raise();
+        new_Archive_Path->raise();
         textBrowser_6->raise();
         textBrowser_8->raise();
         line_8->raise();
         progressBar_4->raise();
-        New_Archiv->raise();
+        New_Archive->raise();
         Help = new QWidget();
         Help->setObjectName(QStringLiteral("Help"));
         textBrowser_13 = new QTextBrowser(Help);
@@ -1686,8 +1686,8 @@ public:
         Configuration_Menu->setText(QApplication::translate("BORG_BackUP_GUI", "C&onfiguration", nullptr));
         Borg_Homepage_Menu->setText(QApplication::translate("BORG_BackUP_GUI", "&Borg Homepage", nullptr));
         Tutorial_Menu->setText(QApplication::translate("BORG_BackUP_GUI", "&Tutorial", nullptr));
-        actionLoad_Archiv->setText(QApplication::translate("BORG_BackUP_GUI", "Load Archiv", nullptr));
-        Set_Archiv->setText(QApplication::translate("BORG_BackUP_GUI", "&Select a BackUP", nullptr));
+        actionLoad_Archive->setText(QApplication::translate("BORG_BackUP_GUI", "Load Archive", nullptr));
+        Set_Archive->setText(QApplication::translate("BORG_BackUP_GUI", "&Select a BackUP", nullptr));
         Open->setText(QApplication::translate("BORG_BackUP_GUI", "&Open", nullptr));
         progressBar_2->setFormat(QApplication::translate("BORG_BackUP_GUI", "%p%", nullptr));
         label_3->setText(QApplication::translate("BORG_BackUP_GUI", "Deduplicated size", nullptr));
@@ -1858,11 +1858,11 @@ public:
         BackUP_Path->setToolTip(QApplication::translate("BORG_BackUP_GUI", "<html><head/><body><p>Select a folder.</p></body></html>", nullptr));
 #endif // QT_NO_TOOLTIP
         BackUP_Path->setText(QApplication::translate("BORG_BackUP_GUI", "BackUP Path", nullptr));
-        Archiv_Key_File->setItemText(0, QApplication::translate("BORG_BackUP_GUI", "none", nullptr));
-        Archiv_Key_File->setItemText(1, QApplication::translate("BORG_BackUP_GUI", "1024++", nullptr));
-        Archiv_Key_File->setItemText(2, QApplication::translate("BORG_BackUP_GUI", "2048++", nullptr));
-        Archiv_Key_File->setItemText(3, QApplication::translate("BORG_BackUP_GUI", "4096++", nullptr));
-        Archiv_Key_File->setItemText(4, QApplication::translate("BORG_BackUP_GUI", "8192++", nullptr));
+        Archive_Key_File->setItemText(0, QApplication::translate("BORG_BackUP_GUI", "none", nullptr));
+        Archive_Key_File->setItemText(1, QApplication::translate("BORG_BackUP_GUI", "1024++", nullptr));
+        Archive_Key_File->setItemText(2, QApplication::translate("BORG_BackUP_GUI", "2048++", nullptr));
+        Archive_Key_File->setItemText(3, QApplication::translate("BORG_BackUP_GUI", "4096++", nullptr));
+        Archive_Key_File->setItemText(4, QApplication::translate("BORG_BackUP_GUI", "8192++", nullptr));
 
         label_19->setText(QApplication::translate("BORG_BackUP_GUI", "Passphrase", nullptr));
 #ifndef QT_NO_TOOLTIP
@@ -1881,9 +1881,9 @@ public:
 "<p align=\"justify\" style=\" margin-top:0px; margin-bottom:5px; margin-left:5px; margin-right:5px; -qt-block-indent:0; text-indent:0px;\"><span style=\" font-family:'Droid Sans Thai'; font-weight:400;\">At </span><span style=\" font-family:'Droid Sans Thai';\">BackUP Name</span><span style=\" font-family:'Droid Sans Thai'; font-weight:400;\"> enter the name of the backup you want to create.</span></p></body></html>", nullptr));
         progressBar_4->setFormat(QString());
 #ifndef QT_NO_TOOLTIP
-        New_Archiv->setToolTip(QApplication::translate("BORG_BackUP_GUI", "<html><head/><body><p>Select a folder.</p></body></html>", nullptr));
+        New_Archive->setToolTip(QApplication::translate("BORG_BackUP_GUI", "<html><head/><body><p>Select a folder.</p></body></html>", nullptr));
 #endif // QT_NO_TOOLTIP
-        New_Archiv->setText(QApplication::translate("BORG_BackUP_GUI", "New Archiv", nullptr));
+        New_Archive->setText(QApplication::translate("BORG_BackUP_GUI", "New Archive", nullptr));
         textBrowser_7->setHtml(QApplication::translate("BORG_BackUP_GUI", "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.0//EN\" \"http://www.w3.org/TR/REC-html40/strict.dtd\">\n"
 "<html><head><meta name=\"qrichtext\" content=\"1\" /><style type=\"text/css\">\n"
 "p, li { white-space: pre-wrap; }\n"
@@ -1894,7 +1894,7 @@ public:
 "p, li { white-space: pre-wrap; }\n"
 "</style></head><body style=\" font-family:'Cantarell'; font-size:12pt; font-weight:600; font-style:normal;\">\n"
 "<p style=\" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\"><span style=\" font-family:'Droid Sans Thai'; font-weight:400;\">Then you can press </span><span style=\" font-family:'Droid Sans Thai';\">Create</span><span style=\" font-family:'Droid Sans Thai'; font-weight:400;\"> and a new empty Borg BackUP will be created for you. </span></p></body></html>", nullptr));
-        tabWidget->setTabText(tabWidget->indexOf(NewArchiv), QApplication::translate("BORG_BackUP_GUI", "&New Archiv", nullptr));
+        tabWidget->setTabText(tabWidget->indexOf(NewArchiv), QApplication::translate("BORG_BackUP_GUI", "&New Archive", nullptr));
         textBrowser_13->setHtml(QApplication::translate("BORG_BackUP_GUI", "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.0//EN\" \"http://www.w3.org/TR/REC-html40/strict.dtd\">\n"
 "<html><head><meta name=\"qrichtext\" content=\"1\" /><style type=\"text/css\">\n"
 "p, li { white-space: pre-wrap; }\n"


### PR DESCRIPTION
I noticed that archive was misspelled as "archiv" in a few places.